### PR TITLE
ci: 更好的缓存支持

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       # msbuild_path: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe
       msvs_version: 2022
-      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
-      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+      ELECTRON_CACHE: ${{ github.workspace }}/node_modules/.cache/electron
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/node_modules/.cache/electron-builder
       
     steps:
       - uses: actions/checkout@v4
@@ -30,24 +30,14 @@ jobs:
         with:
           node-version: 18
           cache: npm
-          
-      - name: Cache Electron
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/.cache/electron
-          key: ${{ runner.os }}-electron-cache-${{ hashFiles(format('{0}{1}', github.workspace, '/package-lock.json')) }}
-          restore-keys: |
-            ${{ runner.os }}-electron-cache-
 
-      - name: Cache Electron-Builder
-        uses: actions/cache@v3
+      # npm ci 的支持缓存版本，减少在本就性能不佳的 windows runner 上的编译时间
+      - id: get-patches-commit-short
+        shell: bash
+        run: echo "commit=$(git log -1 --format="%H" -- patches)" >> $GITHUB_OUTPUT && cat $GITHUB_OUTPUT
+      - uses: AnnAngela/cached_node-modules@v1
         with:
-          path: ${{ github.workspace }}/.cache/electron-builder
-          key: ${{ runner.os }}-electron-builder-cache-${{ hashFiles(format('{0}{1}', github.workspace, '/package-lock.json')) }}
-          restore-keys: |
-            ${{ runner.os }}-electron-builder-cache-
-            
-      - run: npm install
+          customVariable: :patches@{{ steps.get-patches-commit-short.outputs.commit }}
           
       - name: Build the native modules
         run: npm run rebuild


### PR DESCRIPTION
改了以下几点来更好地使用缓存：

1. 将缓存文件夹移动到 `node_modules/.cache` 里，这是个社区广泛使用的缓存目录 (ref: [webpack](https://webpack.js.org/configuration/cache/#cachecachedirectory), [turborepo](https://turbo.build/repo/docs/core-concepts/caching#:~:text=e.g../-,node_modules/.cache,-/turbo/78awdk123.tar), [AVA](https://github.com/avajs/ava/blob/main/docs/06-configuration.md#L48))
2. 使用 [AnnAngela/cached_node-modules](https://github.com/marketplace/actions/cached-node_modules) 统一管理缓存，它会自动识别当前环境的 OS 类型（如 Window）、`package-lock.json` 的最新 commit 短 ID，然后决定是否重新生成缓存；
	*  `get-patches-commit-short` 是用来获取 `patches` 文件夹的最新 commit 短 ID，避免更改了该文件夹后缓存不失效的问题。