### PR TITLE
fix: typo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "commit=$(git log -1 --format="%H" -- patches)" >> $GITHUB_OUTPUT && cat $GITHUB_OUTPUT
       - uses: AnnAngela/cached_node-modules@v1
         with:
-          customVariable: :patches@{{ steps.get-patches-commit-short.outputs.commit }}
+          customVariable: :patches@${{ steps.get-patches-commit-short.outputs.commit }}
           
       - name: Build the native modules
         run: npm run rebuild


### PR DESCRIPTION
修正一个笔误=。=

顺带一提，启用缓存后的 `npm ci` 耗时下降为：

![image](https://github.com/watchingfun/Joi/assets/9762652/f11eb0bb-f3f3-42c5-b538-22a131cd02b7)

主要耗时在下载和解压缓存上